### PR TITLE
Remove dependence on the specific version of the boost library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
 endif()
 
 # Look up required packages and add the include directory to our include path
-find_package(Boost 1.55.0 COMPONENTS filesystem system)
+find_package(Boost 1.55.0 COMPONENTS filesystem system REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(SDL2_ttf REQUIRED)
 find_package(Lua REQUIRED)


### PR DESCRIPTION
Currently, building this project has dependence on specific version(1.55) of the boost library.
This commit changed it so that it not dependent on the specific version of the boost library.