### PR TITLE
Change list of packages to build on the ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ build/Darwin.x86_64.Debug/game/game
 #### Ubuntu
 
 ```
-$ apt-get install cmake libsdl2-dev libsdl2-ttf-dev liblua5.2-dev libboost-dev
+$ apt-get install cmake libsdl2-dev libsdl2-ttf-dev liblua5.2-dev libboost-system-dev libboost-filesystem-dev
 $ ./build.py
 $ build/Linux.x86_64.Debug/game/game
 ```


### PR DESCRIPTION
This commit changed list of packages related to boost for building on the ubuntu.

I was faced with build errors on ubuntu 16.04 follow as:
```
CMakeFiles/game.dir/src/gui/app/app.cc.o: In function `__static_initialization_and_destruction_0(int, int)':
/usr/include/boost/system/error_code.hpp:221: undefined reference to `boost::system::generic_category()'
/usr/include/boost/system/error_code.hpp:222: undefined reference to `boost::system::generic_category()'
/usr/include/boost/system/error_code.hpp:223: undefined reference to `boost::system::system_category()'
CMakeFiles/game.dir/src/gui/app/unit_dialog_view.cc.o: In function `__static_initialization_and_destruction_0(int, int)':
/usr/include/boost/system/error_code.hpp:221: undefined reference to `boost::system::generic_category()'
/usr/include/boost/system/error_code.hpp:222: undefined reference to `boost::system::generic_category()'
/usr/include/boost/system/error_code.hpp:223: undefined reference to `boost::system::system_category()'
```