### PR TITLE
[CI] Use docker for ubuntu build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,12 @@ matrix:
 
         - os: linux
           sudo: required
-          dist: xenial
+          services:
+              - docker
+          dist: trusty
           before_install:
-              - ./ci/install_deps_ubuntu.sh
+              - docker build -t mengde docker
           script:
               # clang format is disabled for ubuntu due to version issue
 #              - ./ci/clang-format.sh
-              - ./build.py
+              - docker run --rm -it -v $(pwd):/root/mengde -w /root/mengde mengde ./build.py


### PR DESCRIPTION
- Travis CI does not officially support xenial
- Use trusty with xenial docker image