### PR TITLE
Update gitignore for pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 /sce/
 /cross/rootfs
 /.vscode
+/tools/*.pyc


### PR DESCRIPTION
This will add /tools/*.pyc files to ignore compile python scripts
- current actual file is ` tools/cmd_helpers.pyc`