### PR TITLE
Modify for Ubuntu 14.04 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For now we only have instructions for build.
 * SDL2
 * SDL2 TTF
 * Lua 5.2
-* boost >= 1.52
+* boost >= 1.55
 
 #### macOS
 

--- a/ci/install_deps_ubuntu.sh
+++ b/ci/install_deps_ubuntu.sh
@@ -3,6 +3,12 @@
 set -e
 
 sudo apt-get -qq update
+
+if [[ `lsb_release -rs` -lt 16 ]]
+then
 sudo apt-get install -y cmake libsdl2-dev libsdl2-ttf-dev liblua5.2-dev libboost-all-dev clang-format
+else
+sudo apt-get install -y cmake libsdl2-dev libsdl2-ttf-dev liblua5.2-dev boost1.55 clang-format-3.4
+fi
 
 exit 0

--- a/ci/install_deps_ubuntu.sh
+++ b/ci/install_deps_ubuntu.sh
@@ -4,7 +4,10 @@ set -e
 
 sudo apt-get -qq update
 
-if [[ `lsb_release -rs` -lt 16 ]]
+version=`lsb_release -rs`
+version_int=${version:0:2}
+
+if [ $version_int -ge 16 ]
 then
 sudo apt-get install -y cmake libsdl2-dev libsdl2-ttf-dev liblua5.2-dev libboost-all-dev clang-format
 else


### PR DESCRIPTION
In Ubuntu 14.04 version, there are problems as below.

1. There is no clang-format package.
```
seok@ubuntu:~/mengde$ ./ci/install_deps_ubuntu.sh 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package clang-format
```

2. Requested version of boost is 1.55, not 1.52. And also libboost-all-dev package in Ubuntu 14.04 is 1.54 version.
```
...
CMake Error at /usr/share/cmake-2.8/Modules/FindBoost.cmake:1131 (message):
  Unable to find the requested Boost libraries.

  Boost version: 1.54.0

  Boost include path: /usr/include

  Detected version of Boost is too old.  Requested version was 1.55 (or newer).
Call Stack (most recent call first):
  CMakeLists.txt:37 (find_package)
...
```

Therefore, I modified to use clang-format-3.4 and boost1.55 in Ubuntu 14.04 environment.
After modifying, I did build test and confirmed the result program runs well.