### PR TITLE
clang-format version update

### DIFF
--- a/ci/install_deps_ubuntu.sh
+++ b/ci/install_deps_ubuntu.sh
@@ -3,6 +3,8 @@
 set -e
 
 sudo apt-get -qq update
-sudo apt-get install -y cmake libsdl2-dev libsdl2-ttf-dev liblua5.2-dev libboost-all-dev clang-format
+sudo apt-get install -y cmake libsdl2-dev libsdl2-ttf-dev liblua5.2-dev libboost-all-dev clang-format-6.0
+sudo rm /usr/bin/clang-format -f
+sudo ln -s /usr/bin/clang-format-6.0 /usr/bin/clang-format
 
 exit 0


### PR DESCRIPTION
Because of many arguments in .clang-format file, clang-format version should be higher than 5.

Update script to install clang-format-6.0