### PR TITLE
[gui] Set priority for `metal` renderer

### DIFF
--- a/game/src/gui/foundation/misc.cc
+++ b/game/src/gui/foundation/misc.cc
@@ -11,6 +11,9 @@ void Misc::Init() {
   if (SDL_Init(SDL_INIT_VIDEO) != 0) {
     throw "SDL_Init Error";
   }
+
+  // metal renderer has priority
+  SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, "metal", SDL_HINT_OVERRIDE);
 }
 
 void Misc::Quit() { SDL_Quit(); }

--- a/game/src/gui/foundation/renderer.cc
+++ b/game/src/gui/foundation/renderer.cc
@@ -13,7 +13,15 @@ Renderer::Renderer(Window* window) {
 #else
                                SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
 #endif
+
   if (handle_ == NULL) throw Misc::GetErrorMessage() + " - SDL_CreateRenderer";
+
+  {
+    SDL_RendererInfo renderer_info;
+    SDL_GetRendererInfo(handle_, &renderer_info);
+    LOG_INFO("Renderer: %s", renderer_info.name);
+  }
+
   SDL_SetRenderDrawColor(handle_, 0xFF, 0xFF, 0xFF, 0xFF);
   SDL_SetRenderDrawBlendMode(handle_, SDL_BLENDMODE_BLEND);
 


### PR DESCRIPTION
As macOS 10.14 Mojave deprecates opengl, we use metal as primary
renderer.