### PR TITLE
Show ItemDetailView as tooltip style

### DIFF
--- a/game/src/gui/app/deploy_view.cc
+++ b/game/src/gui/app/deploy_view.cc
@@ -113,7 +113,7 @@ DeployView::DeployView(const Rect& frame, core::Assets* assets, core::IDeployHel
 
   Rect equipment_select_frame = GetActualFrame();
   equipment_select_frame.w(4 * 96);
-  equipment_select_view_ = new EquipmentSelectView(equipment_select_frame, equipment_set_view);
+  equipment_select_view_ = new EquipmentSelectView(gv, equipment_select_frame, equipment_set_view);
   equipment_select_view_->visible(false);
 
   {  // Initialize equipment_set_view

--- a/game/src/gui/app/deploy_view.cc
+++ b/game/src/gui/app/deploy_view.cc
@@ -113,7 +113,7 @@ DeployView::DeployView(const Rect& frame, core::Assets* assets, core::IDeployHel
 
   Rect equipment_select_frame = GetActualFrame();
   equipment_select_frame.w(4 * 96);
-  equipment_select_view_ = new EquipmentSelectView(gv, equipment_select_frame, equipment_set_view);
+  equipment_select_view_ = new EquipmentSelectView(equipment_select_frame, gv, equipment_set_view);
   equipment_select_view_->visible(false);
 
   {  // Initialize equipment_set_view

--- a/game/src/gui/app/equipment_select_view.cc
+++ b/game/src/gui/app/equipment_select_view.cc
@@ -22,7 +22,7 @@ namespace app {
 // EquipmentIconView
 //
 
-ItemIconView::ItemIconView(GameView* gv, const Rect& frame, const core::EquipmentWithAmount& equipment)
+ItemIconView::ItemIconView(const Rect& frame, GameView* gv, const core::EquipmentWithAmount& equipment)
     : CallbackView(frame), gv_(gv) {
   const string& equipment_id = equipment.object->GetId();
   uint32_t amount = equipment.amount;
@@ -64,7 +64,7 @@ ItemIconView::ItemIconView(GameView* gv, const Rect& frame, const core::Equipmen
 // EquipmentSelectView
 //
 
-EquipmentSelectView::EquipmentSelectView(GameView* gv, const Rect& frame, EquipmentSetView* equipment_set_view)
+EquipmentSelectView::EquipmentSelectView(const Rect& frame, GameView* gv, EquipmentSetView* equipment_set_view)
     : CompositeView(frame),
       gv_(gv),
       hero_(nullptr),
@@ -82,7 +82,7 @@ void EquipmentSelectView::SetEquipments(const vector<core::EquipmentWithAmount>&
   auto hero = assets->LookupHero(hero_->id());  // For non-const core::Hero and capture
   auto equipment_set_view = equipment_set_view_;
   for (auto equipment : equipments) {
-    ItemIconView* item_icon_view = new ItemIconView(gv_, Rect(0, 0, kItemSize, kItemSize), equipment);
+    ItemIconView* item_icon_view = new ItemIconView(Rect(0, 0, kItemSize, kItemSize), gv_, equipment);
     item_icon_view->SetMouseButtonHandler(
         [this, assets, hero, equipment, equipment_set_view](const foundation::MouseButtonEvent& e) {
           if (e.IsLeftButtonUp()) {

--- a/game/src/gui/app/equipment_select_view.cc
+++ b/game/src/gui/app/equipment_select_view.cc
@@ -4,11 +4,14 @@
 #include "core/equipment.h"
 #include "core/equipment_set.h"
 #include "core/hero.h"
+#include "deploy_view.h"
 #include "equipment_set_view.h"
+#include "game_view.h"
 #include "gui/uifw/image_view.h"
 #include "gui/uifw/layout_helper.h"
 #include "gui/uifw/row_major_list_view.h"
 #include "gui/uifw/text_view.h"
+#include "item_detail_view.h"
 #include "resource_path.h"
 
 namespace mengde {
@@ -19,7 +22,8 @@ namespace app {
 // EquipmentIconView
 //
 
-ItemIconView::ItemIconView(const Rect& frame, const core::EquipmentWithAmount& equipment) : CallbackView(frame) {
+ItemIconView::ItemIconView(GameView* gv, const Rect& frame, const core::EquipmentWithAmount& equipment)
+    : CallbackView(frame), gv_(gv) {
   const string& equipment_id = equipment.object->GetId();
   uint32_t amount = equipment.amount;
   bg_color(COLOR("transparent"));
@@ -34,14 +38,23 @@ ItemIconView::ItemIconView(const Rect& frame, const core::EquipmentWithAmount& e
       new TextView(tv_amount_frame, std::to_string(amount), COLOR("white"), 14, LayoutHelper::kAlignRgtTop);
   AddChild(tv_amount);
 
-  SetMouseMotionHandler([this](const foundation::MouseMotionEvent& e) {
+  SetMouseMotionHandler([this, equipment](const foundation::MouseMotionEvent& e) {
+    DeployView* deploy_view = this->gv_->deploy_view();
+    ItemDetailView* item_detail_view = this->gv_->item_detail_tooltip_view();
     if (e.IsMotionOver()) {
       this->bg_color(COLOR("darkgray"));
-      // TODO : Show Item detail tooltip
+      // Show Item Detail ToolTip
+      // DeployView coords + ItemIcon coords + MouseEvent coords + (ItemIcon height/2)
+      Vec2D pos =
+          deploy_view->GetActualFrameCoords() + this->GetFrameCoords() + e.GetCoords() + (this->GetFrameSize().y / 2);
+      item_detail_view->SetCoords(pos);
+      item_detail_view->visible(true);
+      item_detail_view->SetItem(equipment.object);
     } else {
       ASSERT(e.IsMotionOut());
       this->bg_color(COLOR("transparent"));
-      // TODO : Hide Item detail tooltip
+      // Hide Item detail tooltip
+      item_detail_view->visible(false);
     }
     return true;
   });
@@ -51,8 +64,12 @@ ItemIconView::ItemIconView(const Rect& frame, const core::EquipmentWithAmount& e
 // EquipmentSelectView
 //
 
-EquipmentSelectView::EquipmentSelectView(const Rect& frame, EquipmentSetView* equipment_set_view)
-    : CompositeView(frame), hero_(nullptr), equipment_list_view_(nullptr), equipment_set_view_(equipment_set_view) {
+EquipmentSelectView::EquipmentSelectView(GameView* gv, const Rect& frame, EquipmentSetView* equipment_set_view)
+    : CompositeView(frame),
+      gv_(gv),
+      hero_(nullptr),
+      equipment_list_view_(nullptr),
+      equipment_set_view_(equipment_set_view) {
   bg_color(COLOR("black"));
 }
 
@@ -65,7 +82,7 @@ void EquipmentSelectView::SetEquipments(const vector<core::EquipmentWithAmount>&
   auto hero = assets->LookupHero(hero_->id());  // For non-const core::Hero and capture
   auto equipment_set_view = equipment_set_view_;
   for (auto equipment : equipments) {
-    ItemIconView* item_icon_view = new ItemIconView(Rect(0, 0, kItemSize, kItemSize), equipment);
+    ItemIconView* item_icon_view = new ItemIconView(gv_, Rect(0, 0, kItemSize, kItemSize), equipment);
     item_icon_view->SetMouseButtonHandler(
         [this, assets, hero, equipment, equipment_set_view](const foundation::MouseButtonEvent& e) {
           if (e.IsLeftButtonUp()) {

--- a/game/src/gui/app/equipment_select_view.h
+++ b/game/src/gui/app/equipment_select_view.h
@@ -19,19 +19,24 @@ namespace gui {
 namespace app {
 
 class EquipmentSetView;
+class GameView;
 
 class ItemIconView : public CallbackView {
  public:
-  ItemIconView(const Rect&, const core::EquipmentWithAmount&);
+  ItemIconView(GameView*, const Rect&, const core::EquipmentWithAmount&);
+
+ private:
+  GameView* gv_;
 };
 
 class EquipmentSelectView : public CompositeView {
  public:
-  EquipmentSelectView(const Rect&, EquipmentSetView*);
+  EquipmentSelectView(GameView*, const Rect&, EquipmentSetView*);
   void SetHero(const core::Hero* hero) { hero_ = hero; }
   void SetEquipments(const vector<core::EquipmentWithAmount>&, core::Assets*);
 
  private:
+  GameView* gv_;
   const core::Hero* hero_;
   RowMajorListView* equipment_list_view_;
   EquipmentSetView* equipment_set_view_;

--- a/game/src/gui/app/equipment_select_view.h
+++ b/game/src/gui/app/equipment_select_view.h
@@ -23,7 +23,7 @@ class GameView;
 
 class ItemIconView : public CallbackView {
  public:
-  ItemIconView(GameView*, const Rect&, const core::EquipmentWithAmount&);
+  ItemIconView(const Rect&, GameView*, const core::EquipmentWithAmount&);
 
  private:
   GameView* gv_;
@@ -31,7 +31,7 @@ class ItemIconView : public CallbackView {
 
 class EquipmentSelectView : public CompositeView {
  public:
-  EquipmentSelectView(GameView*, const Rect&, EquipmentSetView*);
+  EquipmentSelectView(const Rect&, GameView*, EquipmentSetView*);
   void SetHero(const core::Hero* hero) { hero_ = hero; }
   void SetEquipments(const vector<core::EquipmentWithAmount>&, core::Assets*);
 

--- a/game/src/gui/app/game_view.h
+++ b/game/src/gui/app/game_view.h
@@ -36,6 +36,7 @@ class MagicListView;
 class TerrainInfoView;
 class UnitListView;
 class UnitActionView;
+class ItemDetailView;
 
 class UIViews;
 
@@ -75,6 +76,7 @@ class GameView : public View {
   void CenterCamera(Vec2D);
 
  public:
+  DeployView* deploy_view() { return ui_views_->deploy_view(); }
   TerrainInfoView* terrain_info_view() { return ui_views_->terrain_info_view(); }
   UnitListView* unit_list_view() { return ui_views_->unit_list_view(); }
   UnitDialogView* unit_dialog_view() { return ui_views_->unit_dialog_view(); }
@@ -85,6 +87,7 @@ class GameView : public View {
   ModalDialogView* dialog_view() { return ui_views_->dialog_view(); }
   MagicListView* magic_list_view() { return ui_views_->magic_list_view(); }
   UnitActionView* unit_action_view() { return ui_views_->unit_action_view(); }
+  ItemDetailView* item_detail_tooltip_view() { return ui_views_->item_detail_tooltip_view(); }
 
  public:
   Vec2D GetMouseCoords() { return mouse_coords_; }

--- a/game/src/gui/app/item_detail_view.cc
+++ b/game/src/gui/app/item_detail_view.cc
@@ -11,11 +11,15 @@ namespace app {
 
 // TODO : param 2, equipment should be changed to 'Item'
 ItemDetailView::ItemDetailView(const Rect& frame, const core::Equipment* equipment) : CompositeView(frame) {
-  Rect iv_frame = LayoutHelper::CalcPosition(GetActualFrame().size(), {32, 32}, LayoutHelper::kAlignLftMid);
+  const int kAlpha = 160;
+  bg_color({64, 64, 64, kAlpha});
+  padding(8);
+
+  Rect iv_frame = LayoutHelper::CalcPosition(GetActualFrame().size(), {32, 32}, LayoutHelper::kAlignLftTop);
   iv_image_ = new ImageView(iv_frame, rcpath::EquipmentModelPath("60-1").ToString());
   Rect tv_name_frame = {32 + 8, 0, 164, 16};
   tv_name_ = new TextView(tv_name_frame);
-  Rect tv_desc_frame = {32 + 8, 0, 164, 52};
+  Rect tv_desc_frame = {32 + 8, 20, 164, 52};
   tv_desc_ = new TextView(tv_desc_frame);
   AddChild(iv_image_);
   AddChild(tv_name_);

--- a/game/src/gui/app/item_detail_view.h
+++ b/game/src/gui/app/item_detail_view.h
@@ -18,7 +18,7 @@ namespace app {
 
 class ItemDetailView : public CompositeView {
  public:
-  ItemDetailView(const Rect&, const core::Equipment*);
+  ItemDetailView(const Rect&, const core::Equipment* = NULL);
 
  public:
   void SetItem(const core::Equipment*);

--- a/game/src/gui/app/ui_views.cc
+++ b/game/src/gui/app/ui_views.cc
@@ -9,6 +9,7 @@
 #include "gui/uifw/modal_dialog_view.h"
 #include "gui/uifw/modal_view.h"
 #include "gui/uifw/scroll_view.h"
+#include "item_detail_view.h"
 #include "magic_list_view.h"
 #include "terrain_info_view.h"
 #include "unit_action_view.h"
@@ -32,6 +33,14 @@ UIViews::UIViews(const Rect& rect, core::Scenario* scenario, GameView* game_view
     deploy_view_ = new DeployView(frame, assets, stage, game_view, base_path);
     deploy_view_->visible(true);
     AddChild(deploy_view_);
+  }
+
+  {  // Initialize item_detail_tooltip_view_
+    Rect item_detail_tooltip_frame =
+        LayoutHelper::CalcPosition(GetFrameSize(), {220, 80}, LayoutHelper::kAlignLftTop, LayoutHelper::kDefaultSpace);
+    item_detail_tooltip_view_ = new ItemDetailView(item_detail_tooltip_frame);
+    item_detail_tooltip_view_->visible(false);
+    AddChild(item_detail_tooltip_view_);
   }
 
   {  // Initialize unit_view_

--- a/game/src/gui/app/ui_views.h
+++ b/game/src/gui/app/ui_views.h
@@ -27,6 +27,7 @@ class MagicListView;
 class TerrainInfoView;
 class UnitListView;
 class UnitActionView;
+class ItemDetailView;
 
 class UIViews : public CompositeView {
  public:
@@ -34,6 +35,7 @@ class UIViews : public CompositeView {
 
  public:
   // UI view getters
+  DeployView* deploy_view() { return deploy_view_; }
   TerrainInfoView* terrain_info_view() { return terrain_info_view_; }
   UnitListView* unit_list_view() { return unit_list_view_; }
   UnitDialogView* unit_dialog_view() { return unit_dialog_view_; }
@@ -44,9 +46,11 @@ class UIViews : public CompositeView {
   ModalDialogView* dialog_view() { return dialog_view_; }
   MagicListView* magic_list_view() { return magic_list_view_; }
   UnitActionView* unit_action_view() { return unit_action_view_; }
+  ItemDetailView* item_detail_tooltip_view() { return item_detail_tooltip_view_; }
 
  private:
   DeployView* deploy_view_;
+  ItemDetailView* item_detail_tooltip_view_;
   UnitTooltipView* unit_tooltip_view_;
   UnitView* unit_view_;
   ControlView* control_view_;


### PR DESCRIPTION
Related : #120

This commit shows ItemDetailView as tooltip style.

- Get GameView param in EquipmentSelectView, ItemIconView
- Add ItemDetailView to UIViews
- Add DeployView/ItemDetailView getter in GameView,UIViews
- Refactor ItemDetailView to more pretty
- Show ItemDetailView as tooltip style

Signed-off-by: sjsujin.kim <sjsujin.kim@naver.com>